### PR TITLE
feat: use offscreen document for automatic color scheme detection

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,8 +23,9 @@
   "permissions": [
     "storage",
     "activeTab",
-    "clipboardRead"
+    "clipboardRead",
+    "offscreen"
   ],
   "default_locale": "en",
-  "minimum_chrome_version": "88"
+  "minimum_chrome_version": "109"
 }

--- a/offscreen.html
+++ b/offscreen.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body>
+  <script type="module" src="/src/offscreen.ts"></script>
+</body>
+</html>

--- a/src/Popup.vue
+++ b/src/Popup.vue
@@ -47,10 +47,6 @@ onMounted(async () => {
     // get current tab url
     const tab = await getCurrentTab()
     currentUrl.value = tab?.url
-
-    // set color scheme
-    const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-    chrome.runtime.sendMessage({ type: 'SET_COLOR_SCHEME', data: { colorScheme: isDark ? 'dark' : 'light' } })
 })
 
 // get info of the current tab

--- a/src/background.ts
+++ b/src/background.ts
@@ -33,6 +33,21 @@ chrome.storage.local.get({
     colorSchemeStored.value = items.colorScheme;
 });
 
+async function ensureOffscreenDocument() {
+    const contexts = await chrome.runtime.getContexts({
+        contextTypes: [chrome.runtime.ContextType.OFFSCREEN_DOCUMENT],
+    });
+    if (contexts.length === 0) {
+        await chrome.offscreen.createDocument({
+            url: 'offscreen.html',
+            reasons: [chrome.offscreen.Reason.MATCH_MEDIA],
+            justification: 'Detect system color scheme changes to update the action icon',
+        });
+    }
+}
+
+ensureOffscreenDocument();
+
 function setIcon() {
     const color = optionsStored.value.iconColor;
     let c = '';
@@ -91,4 +106,5 @@ chrome.runtime.onMessage.addListener(({ type, data }, sender, sendResponse) => {
 // adding contextmenu on install
 chrome.runtime.onInstalled.addListener(() => {
     setIcon();
+    ensureOffscreenDocument();
 });

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1,0 +1,28 @@
+const mq = window.matchMedia('(prefers-color-scheme: dark)')
+
+function sendColorScheme(isDark: boolean) {
+    chrome.runtime.sendMessage({
+        type: 'SET_COLOR_SCHEME',
+        data: { colorScheme: isDark ? 'dark' : 'light' },
+    })
+}
+
+// Send initial value immediately
+sendColorScheme(mq.matches)
+
+// Listen for changes via matchMedia event
+mq.addEventListener('change', (e) => {
+    sendColorScheme(e.matches)
+})
+
+// Poll periodically as a fallback — the matchMedia event alone isn't always
+// reliable when the service worker has been sleeping and the offscreen doc was
+// recreated, because the first 'change' event may have been missed.
+let lastKnownIsDark = mq.matches
+setInterval(() => {
+    const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    if (isDark !== lastKnownIsDark) {
+        lastKnownIsDark = isDark
+        sendColorScheme(isDark)
+    }
+}, 10_000)


### PR DESCRIPTION
## Summary

- **Replaces popup-based detection** — color scheme was previously read only when the popup opened, meaning the action icon stayed stale until the user interacted with it
- **Adds a persistent offscreen document** (`offscreen.html` / `src/offscreen.ts`) that lives outside the service worker sleep cycle, using `matchMedia` events for instant detection plus a `setInterval` poll every 10 seconds as a fallback
- **`ensureOffscreenDocument()`** in the background service worker creates the offscreen doc on startup and `onInstalled`, recreating it if Chrome ever closes it
- Adds `"offscreen"` permission and bumps `minimum_chrome_version` to `109` (required for Offscreen API)

## Test plan

- [ ] Change system color scheme (light ↔ dark) and confirm the action icon updates within ~10 seconds without clicking anything
- [ ] Open the popup — icon should already reflect the correct scheme before any interaction
- [ ] Reload the extension and change the scheme — icon should still auto-update (offscreen doc recreated on startup)
- [ ] Verify no errors in the service worker console related to offscreen document creation